### PR TITLE
Fix typo that is preventing external_dial to work

### DIFF
--- a/src/Agent/Client.php
+++ b/src/Agent/Client.php
@@ -158,7 +158,7 @@ class Client extends BaseClient {
         $options = $this->encode($options) + [
             'agent_user' => urlencode(trim($agent_user)),
             'function' => 'external_dial',
-            'value' => urlencode(trim($options['phone_numer'])),
+            'value' => urlencode(trim($options['phone_number'])),
             'phone_code' => urlencode(trim($options['phone_code'] ?? '')),
             'search' => 'YES',
             'preview' => 'NO',


### PR DESCRIPTION
There is a typo on the external_dial function and is not working at all. This commit contains the fix for the issue.